### PR TITLE
Update graal

### DIFF
--- a/src/main/g8/Dockerfile
+++ b/src/main/g8/Dockerfile
@@ -16,7 +16,7 @@
 # BUILDER:
 #
 # Use a dockerized native builder
-FROM oracle/graalvm-ce:19.2.1 as binarybuilder
+FROM oracle/graalvm-ce:20.2.0 as binarybuilder
 
 MAINTAINER $maintainer$
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -21,7 +21,7 @@ lazy val root = (project in file("."))
     ),
 
     // Concurrency:
-    libraryDependencies += "io.monix" %% "monix" % "3.1.0",
+    libraryDependencies += "io.monix" %% "monix" % "3.2.2",
 
     // Arg Parsing:
     libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.0-RC2",

--- a/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
+++ b/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
@@ -41,7 +41,7 @@ object DemoParallelism extends LazyLogging {
     // The list of all tasks needed for execution:
     val tasks = for { _ <- 0L until iterations } yield detectCircularity
     // Gathering tasks, then summing the final result:
-    val aggregate = Task.gather(tasks).map(_.sum)
+    val aggregate = Task.parSequence(tasks).map(_.sum)
     // Calculating pi from the aggregate:
     aggregate.map { 4.0 * _ / (iterations - 1) }
   }


### PR DESCRIPTION
I was playing around with benchmarks a lot for this PR and noticed some strangeness. I tried different variations of CPU count, iteration count, monix version, and graal version. Strangely enough, setting the parallelism to different values didn't seem to benefit performance in any configuration I could find. In some cases, it would even result in much worse performance.

I'm not gonna address that issue in this PR though, since the solution I found comes with some controversy to say the least. For the time being, let's focus on the easy win included in this PR, which was bumping the graal version. Modifying the monix version had no noticeable effect on performance, but modifying the graal version came with some big wins.

I built two docker images, the only difference between the two was the graal version. After the images were built, I then ran `docker run X` 3 times each for a variety of configurations.

Disclaimers:
- The benchmark times below include the time it took the container to spin up.
- All benchmarks were run using the master branch. The only change was the graal version.

| Parallelism |  Iterations  |   Graal Version  | Run 1 duration |  Run 2 duration | Run 3 duration |
| --------------- | -------- | ------- | ------- | ------- | --- | 
| 1 | 100,000 | 19.2.1 | 0.67s | 0.68s | 0.69s |
| 1 | 100,000 | 20.2.0 | 0.70s | 0.65s | 0.62s |
| 1 | 1,000,000 | 19.2.1 | 4.48s | 4.91s | 3.77s | 
| 1 | 1,000,000 | 20.2.0 | 3.53s | 3.43s | 3.37s |
| 1 | 10,000,000 | 19.2.1 | 70.27s | 65.96s | 70.53s |
| 1 | 10,000,000 | 20.2.0 |56.79s | 57.15s | 56.84s |