### PR TITLE
an arguable improvement to monix usage

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,10 +14,33 @@ lazy val root = (project in file("."))
     // Options used by `native-image` when building native image.
     // https://www.graalvm.org/docs/reference-manual/native-image/
     graalVMNativeImageOptions ++= Seq(
-        "--initialize-at-build-time", // Auto-packs dependent libs at build-time
-        "--no-fallback", // Bakes-in run-time reflection (alternately: --auto-fallback, --force-fallback)
-        "--no-server", // Won't be running `graalvm-native-image:packageBin` often, so one less thing to break
-        "--static" // Disable for OSX (non-docker) builds - Forces statically-linked binary, compatible with libc (linux)
+      "--initialize-at-build-time", // Auto-packs dependent libs at build-time
+      "--no-fallback", // Bakes-in run-time reflection (alternately: --auto-fallback, --force-fallback)
+      "--no-server" // Won't be running `graalvm-native-image:packageBin` often, so one less thing to break
+    ),
+    // Additional options used by `native-image` when building native image that vary based on the
+    // operating system of the machine that is building the image
+    graalVMNativeImageOptions ++= {
+      // Note: Ideally, we should be checking if the current system has a working libc implementation here,
+      // but os.name works surprisingly well in most cases.
+      System.getProperty("os.name").toLowerCase match {
+        case mac if mac.contains("mac") =>
+          Nil
+        case win if win.contains("win") =>
+          Nil
+        case _ =>
+          // Forces statically-linked binary, compatible with libc (linux)
+          Seq("--static")
+      }
+    },
+
+    // Contains substitutions that are necessary for native image creation. These substitutions are required since monix
+    // depends on JCTools which contains a lot of code that can't be compiled by graal native:
+    libraryDependencies ++= Seq(
+      "science.doing" % "jctools-graal-native_20_2_0" % "1.0.0",
+      // Important: Keep the version of the "org.graalvm.nativeimage:svm" dependency synced with whatever version of
+      // graal we are using!
+      "org.graalvm.nativeimage" % "svm" % "20.2.0" % Provided
     ),
 
     // Concurrency:
@@ -31,5 +54,5 @@ lazy val root = (project in file("."))
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3", // See README.md for why we don't use log4j2
 
     // Testing:
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0" % Test
   )

--- a/src/main/g8/src/main/scala/$package$/DemoLogging.scala
+++ b/src/main/g8/src/main/scala/$package$/DemoLogging.scala
@@ -1,15 +1,14 @@
 package $package$
 
 import com.typesafe.scalalogging.LazyLogging
-
-import scala.math.random
+import monix.eval.Task
 
 object DemoLogging extends LazyLogging {
 
   /**
     * Demonstrates log levels and usage of scalalogging -> slf4j -> logbac
     */
-  def apply(name: String): Unit = {
+  def apply(name: String): Task[Unit] = Task {
     logger.info(s"Hello, \$name!")
 
     logger.error("Bad Stuff")

--- a/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
+++ b/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
@@ -41,8 +41,7 @@ object DemoParallelism extends LazyLogging {
     })
 
     // log the results
-    timeTook = calculate._1
-    pi = calculate._2
+    (timeTook, pi) = calculate
     _ <- Task {
       logger.info(s"Pi is roughly \${pi}. (Took \${timeTook.toMillis}ms)")
     }

--- a/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
+++ b/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
@@ -1,48 +1,75 @@
 package $package$
 
+import cats.effect.Resource
 import com.typesafe.scalalogging.LazyLogging
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
 
 object DemoParallelism extends LazyLogging {
 
   /**
-    * Demonstrates effective parallelism using Monix and Monte-Carlo pi calculation.
-    *
-    * @param iterations  Iterations to calculate pi for
-    * @param parallelism Concurrent processes
-    */
-  def apply(iterations: Long, parallelism: Int): Unit = {
-    logger.info(f"Will approximate Pi with \$iterations%,d iterations of random bubble-filling and \$parallelism%,d parallel processes...")
+   * Demonstrates effective parallelism using Monix and Monte-Carlo pi calculation.
+   *
+   * @param iterations  Iterations to calculate pi for
+   * @param parallelism Concurrent processes
+   */
+  def apply(iterations: Long, parallelism: Int): Task[Double] = for {
+    // log that the work is starting
+    _ <- Task {
+      logger.info(f"Will approximate Pi with \$iterations%,d iterations of random bubble-filling and up to \$parallelism%,d parallel processes...")
+    }
 
-    // Scheduler for parallelism:
-    implicit val s: Scheduler = Scheduler.forkJoin(parallelism, maxThreads = 1000)
+    // create scheduler resource based on desired parallelism (it will be closed once we have finished our calculations)
+    schedulerResource = Resource.make(acquire = Task {
+      Scheduler.forkJoin(parallelism = parallelism, maxThreads = 1000)
+    })(release = s => Task { s.shutdown() })
 
-    // Approximation of pi using iteration:
-    val pi = approximatePi(iterations).runToFuture
+    // then use the scheduler to...
+    calculate <- schedulerResource.use(scheduler => {
+      // calculate an approximation of pi
+      approximatePi(parallelism, iterations)
+        // measure how long it took to perform the calculation
+        .timed
+        // set a timeout of 30 seconds
+        .timeout(30.seconds)
+        // insure the process runs on the provided scheduler
+        .executeOn(scheduler)
+    })
 
-    logger.info(s"Pi is roughly \${Await.result(pi, atMost = 30.seconds)}")
+    // log the results
+    timeTook = calculate._1
+    pi = calculate._2
+    _ <- Task {
+      logger.info(s"Pi is roughly \${pi}. (Took \${timeTook.toMillis}ms)")
+    }
+  } yield {
+    pi
   }
 
   /**
     * Approximate pi via [[https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Summing_a_circle's_area Monte Carlo method]].
     */
-  def approximatePi(iterations: Long, seed: Int = 13): Task[Double] = {
+  def approximatePi(parallelism: Int, iterations: Long, seed: Int = 13): Task[Double] = {
     val random = new Random(seed)
+
     // Kernel: projects a random point to detect if within bounds of a circle:
     val detectCircularity: Task[Long] = Task { (random.nextDouble(), random.nextDouble()) }
       .map { case (x, y) => (x * 2 - 1, y * 2 - 1) }
       .map { case (x, y) => if (x * x + y * y <= 1) 1 else 0 }
 
-    // The list of all tasks needed for execution:
-    val tasks = for { _ <- 0L until iterations } yield detectCircularity
-    // Gathering tasks, then summing the final result:
-    val aggregate = Task.parSequence(tasks).map(_.sum)
-    // Calculating pi from the aggregate:
-    aggregate.map { 4.0 * _ / (iterations - 1) }
+    // create a stream of "observable events" matching the desired iterations
+    Observable.range(0, iterations)
+      // for each iteration, create a projection and check it
+      .mapParallelUnordered(parallelism)(_ => detectCircularity)
+      // sum the results of each detection
+      .sumL
+      // finally, calculate pi from the aggregate sum
+      .map(sum => {
+        4.0 * sum / (iterations - 1)
+      })
   }
 }

--- a/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
+++ b/src/main/g8/src/main/scala/$package$/DemoParallelism.scala
@@ -36,7 +36,7 @@ object DemoParallelism extends LazyLogging {
         .timed
         // set a timeout of 30 seconds
         .timeout(30.seconds)
-        // insure the process runs on the provided scheduler
+        // ensure the process runs on the provided scheduler
         .executeOn(scheduler)
     })
 

--- a/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/src/main/scala/$package$/Main.scala
@@ -18,8 +18,6 @@ import monix.execution.Scheduler
   */
 object Main extends TaskApp with LazyLogging {
 
-  override protected def scheduler: Scheduler = Scheduler.computation()
-
   override def run(rawArgs: List[String]): Task[ExitCode] = {
     val appTask = Args.parse(rawArgs) {
       case Args(Hi(n)) =>

--- a/src/main/g8/src/test/scala/$package$/ParallelismSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/ParallelismSpec.scala
@@ -10,27 +10,28 @@ class ParallelismSpec extends BaseSpec {
 
   describe("Parallelism Demo") {
 
-    implicit val s: Scheduler = Scheduler.singleThread("TestScheduler")
+    describe("with sequential pi calculation") {
 
-    describe("with pi calculation") {
+      implicit val s: Scheduler = Scheduler.singleThread("TestScheduler")
 
-      it ("should approximate pi within a digit of precision with 100 iterations") {
-        val futurePi = DemoParallelism.approximatePi(100).runToFuture
+      it("should approximate pi within a digit of precision with 100 iterations") {
+        val futurePi = DemoParallelism.approximatePi(1, 100).runToFuture
         val pi = Await.result(futurePi, atMost = 5.seconds)
         assert(pi > 3 && pi < 4)
       }
 
-      it ("should approximate pi within two digits of precision with 1000 iterations") {
-        val futurePi = DemoParallelism.approximatePi(1000).runToFuture
+      it("should approximate pi within two digits of precision with 1000 iterations") {
+        val futurePi = DemoParallelism.approximatePi(1, 1000).runToFuture
         val pi = Await.result(futurePi, atMost = 5.seconds)
         assert(pi > 3.1 && pi < 3.2)
       }
 
-      it ("should approximate pi within three digits of precision with 10000 iterations") {
-        val futurePi = DemoParallelism.approximatePi(10000).runToFuture
+      it("should approximate pi within three digits of precision with 10000 iterations") {
+        val futurePi = DemoParallelism.approximatePi(1, 10000).runToFuture
         val pi = Await.result(futurePi, atMost = 5.seconds)
         assert(pi > 3.14 && pi < 3.16)
       }
     }
   }
+
 }

--- a/src/main/g8/src/test/scala/$package$/spec/BaseSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/spec/BaseSpec.scala
@@ -1,6 +1,6 @@
 package $package$.spec
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * This should be the base-level class to guarantee congruency among specs across your tests.
@@ -16,4 +16,4 @@ import org.scalatest.FunSpec
   * @author sbchapin
   * @since 11/11/19.
   */
-trait BaseSpec extends FunSpec
+trait BaseSpec extends AnyFunSpec


### PR DESCRIPTION
Changelist:
- Wrap main with TaskApp
- Instantiate scheduler on the fly using `cats.effect.Resource` cause we like closin' stuff
- Try out reactivex-based (using monix Observable) approach for ParallelismDemo
- Add [jctools-graal-native](https://github.com/SwiftEngineer/jctools-graal-native) to fix segmentation faults that would otherwise occur due to monix's indirect use of `sun.misc.Unsafe` (and friends).
- update scalatest to `3.2.0`